### PR TITLE
Fixed test when using Zope 4.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,7 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Fixed test when using Zope 4.  [maurits]
 
 
 3.0.1 (2016-11-17)

--- a/plone/theme/README.rst
+++ b/plone/theme/README.rst
@@ -61,11 +61,8 @@ The other outputs "My Theme".
 
 Before we turn on the skin, we will get the default view.
 
-    >>> from plone.testing import z2
-
     >>> from plone.testing.z2 import Browser
-    >>> with z2.zopeApp() as app:
-    ...     browser = Browser(app)
+    >>> browser = Browser(layer['app'])
 
     >>> browser.open(layer['portal'].absolute_url() + '/@@layer-test-view')
     >>> print browser.contents


### PR DESCRIPTION
The README.rst test was instantiating an app, where it should just use the app from the layer.